### PR TITLE
Normalize devlog front matter and tooling

### DIFF
--- a/docs/.github/workflows/devlog-frontmatter.yml
+++ b/docs/.github/workflows/devlog-frontmatter.yml
@@ -1,0 +1,30 @@
+name: Devlog Front Matter
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  fix:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm run fix:devlog || true
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [[ -n $(git status --porcelain) ]]; then
+            git add -A
+            git commit -m "Normalize devlog front matter (auto)"
+            git push
+          else
+            echo "No changes."
+          fi

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: OXI Docs
+title: OXI-DOCS
 baseurl: /OXI-DOCS
 permalink: pretty
 markdown: kramdown
@@ -17,5 +17,18 @@ collections:
     output: true
   devlog:
     output: true
+    permalink: /devlog/:slug/
   changelog:
     output: true
+
+feed:
+  collections:
+    - devlog
+
+defaults:
+  - scope:
+      path: "_devlog"
+      type: "devlog"
+    values:
+      layout: post
+      tags: ["devlog"]

--- a/docs/_devlog/8-12-25.md
+++ b/docs/_devlog/8-12-25.md
@@ -1,3 +1,10 @@
+---
+layout: post
+title: "Dev Log — 2025-08-12"
+date: "2025-08-12"
+slug: "2025-08-12"
+tags: ["devlog"]
+---
 Dev Log – August 12, 2025
 Today was a cleanup and alignment day for OXI. I focused on getting the Unity layer to speak in native Unity types and tightening the provider ↔ receiver loop so I can drop components in a scene and see results immediately.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "oxi-docs",
+  "private": true,
+  "scripts": {
+    "fix:devlog": "node tools/fix-devlog-frontmatter.js"
+  }
+}

--- a/docs/tools/fix-devlog-frontmatter.js
+++ b/docs/tools/fix-devlog-frontmatter.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+const dir = path.join(__dirname, '..', '_devlog');
+const re = /^(\d{1,2})-(\d{1,2})-(\d{2})(?:-(s\d{2}))?\.md$/i;
+
+const pad = n => String(n).padStart(2, '0');
+const y2k = yy => String(2000 + parseInt(yy, 10));
+
+for (const file of fs.readdirSync(dir)) {
+  if (!file.endsWith('.md')) continue;
+  const m = file.match(re);
+  if (!m) { console.warn('Skipping (name does not match):', file); continue; }
+
+  const [, mth, day, yy, sup] = m;
+  const yyyy = y2k(yy);
+  const dateISO = `${yyyy}-${pad(mth)}-${pad(day)}`;
+  const slug = sup ? `${dateISO}-${sup}` : dateISO;       // ex: 2025-08-12-s01
+  const title = `Dev Log — ${dateISO}${sup ? ` ${sup}` : ''}`;
+
+  const full = path.join(dir, file);
+  const raw = fs.readFileSync(full, 'utf8');
+
+  if (raw.startsWith('---\n')) {
+    console.log('Front matter present:', file);
+    continue;
+  }
+
+  const fm = [
+    '---',
+    'layout: post',
+    `title: "${title}"`,
+    `date: "${dateISO}"`,
+    `slug: "${slug}"`,
+    'tags: ["devlog"]',
+    '---',
+    ''
+  ].join('\n');
+
+  fs.writeFileSync(full, fm + raw, 'utf8');
+  console.log('Added front matter:', file);
+}


### PR DESCRIPTION
## Summary
- configure devlog collection for slug-based permalinks and RSS-only feed
- add Node script to generate devlog front matter from filenames and expose via npm script
- add CI workflow to auto-fix missing devlog front matter

## Testing
- `npm run fix:devlog`


------
https://chatgpt.com/codex/tasks/task_e_689e2f5816b8832ea3f067413ad1f2d4