### PR TITLE
feat: add home page with latest dev logs

### DIFF
--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -1,0 +1,9 @@
+:root { --gap: 1rem; }
+body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+.hero { padding: 2rem 1rem; }
+.cta-row { display: flex; gap: .75rem; margin-top: 1rem; flex-wrap: wrap; }
+.btn { display: inline-block; padding: .6rem .9rem; border-radius: .5rem; background: #111827; color: #fff; text-decoration: none; }
+.latest-devlog { padding: 1rem; }
+.post-list { list-style: none; padding: 0; margin: 0; }
+.post-list li { margin: 0 0 .75rem 0; }
+.post-date { color: #6b7280; font-size: .9rem; margin-left: .5rem; }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,30 @@
 ---
 layout: default
 title: Home
+permalink: /
 ---
 
-# Welcome to OXI Docs
+<section class="hero">
+  <h1>OXI - OpenXR Interactions: Reducing the pain of XR Development</h1>
+  <p>A lightweight, OpenXR-aligned toolkit with a clear, strongly-typed path API and Unity 6 integration.</p>
+  <div class="cta-row">
+    <a class="btn" href="/manual/">OXI Manual</a>
+    <a class="btn" href="/api/latest/">API Reference</a>
+    <a class="btn" href="/devlog/">Dev Logs</a>
+  </div>
+</section>
 
-This is the placeholder homepage for the documentation site.
+<section class="latest-devlog">
+  <h2>Latest Dev Logs</h2>
+  <ul class="post-list">
+    {% assign posts = site.devlog | sort: 'date' | reverse %}
+    {% for post in posts limit:3 %}
+      <li>
+        <a href="{{ post.url }}">{{ post.title }}</a>
+        <span class="post-date">{{ post.date | date: "%b %d, %Y" }}</span>
+        {% if post.excerpt %}<p>{{ post.excerpt | strip_html | truncate: 160 }}</p>{% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+  <p><a href="/devlog/">View all dev logs</a> · <a href="/feed.xml">RSS</a></p>
+</section>


### PR DESCRIPTION
## Summary
- replace placeholder docs index with hero, CTAs, and latest dev log listings
- add minimal site stylesheet for basic layout

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll bundler` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e32d30f98832eada3d43e664eadce